### PR TITLE
Add `strict-map`

### DIFF
--- a/src/chimera/core.cljc
+++ b/src/chimera/core.cljc
@@ -2,3 +2,4 @@
 
 (def any? (complement not-any?))
 (def not-nil? (complement nil?))
+(def strict-map (comp doall map))


### PR DESCRIPTION
compose `doall` and `map` to have a strict version of map instead of repeating it all over.
