### PR TITLE
Move date `format-date` to chimera.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
       [path]
       (str "resources/public/js/compiled/" path))
 
-(defproject onaio/chimera "0.0.6-format-date-SNAPSHOT"
+(defproject onaio/chimera "0.0.6-SNAPSHOT"
   :description "Collection of useful Clojure(Script) functions."
   :dependencies [[clj-time "0.12.2"]
                  [com.cognitect/transit-cljs "0.8.239"]

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
       [path]
       (str "resources/public/js/compiled/" path))
 
-(defproject onaio/chimera "0.0.6-SNAPSHOT"
-  :description "Collection of useful Clojure functions."
+(defproject onaio/chimera "0.0.6-format-date-SNAPSHOT"
+  :description "Collection of useful Clojure(Script) functions."
   :dependencies [[clj-time "0.12.2"]
                  [com.cognitect/transit-cljs "0.8.239"]
                  [com.taoensso/tempura "1.0.0"]
@@ -17,7 +17,9 @@
                   :exclusions [org.clojure/clojure]]
                  [org.clojure/core.async "0.2.395"]
                  [org.omcljs/om "0.9.0"]
-                 [slingshot "0.12.2"]]
+                 [slingshot "0.12.2"]
+                 ;; JS
+                 [cljsjs/moment "2.10.6-4"]]
   :license "Apache 2"
   :url "https://github.com/onaio/chimera"
   :profiles {:dev {:dependencies [[midje "1.8.3"]]}}

--- a/src/chimera/date.cljc
+++ b/src/chimera/date.cljc
@@ -1,0 +1,10 @@
+(ns chimera.date
+  #?(:cljs (:require [cljsjs.moment :as m])))
+
+#?(:cljs (defn format-date
+           "If JS doesn't think it's a valid date return the date provided."
+           [date]
+           (if (or (js/isNaN (new js/Date date))
+                   (= (new js/Date date) "Invalid Date"))
+             date
+             (-> date js/moment (.format "ll")))))

--- a/test/chimera/date_test.cljs
+++ b/test/chimera/date_test.cljs
@@ -1,0 +1,11 @@
+(ns chimera.date-test
+  (:require-macros [cljs.test :refer (is deftest testing)])
+  (:require [chimera.date :refer [format-date]]))
+
+(deftest compositions-api
+  (testing "Returns the input if js/Date finds the date to be invalid"
+    (is (= (format-date "")                         ""))
+    (is (= (format-date "2014 04 25")               "2014 04 25"))
+    (is (= (format-date "2014 04 25 to 2014 06 13") "2014 04 25 to 2014 06 13"))
+    (is (= (format-date "2014-04-25T01:32:21.196Z") "Apr 25, 2014"))
+    (is (= (format-date "11:12")                    "11:12"))))

--- a/test/test_runner.cljs
+++ b/test/test_runner.cljs
@@ -2,6 +2,7 @@
   (:require
    [cljs.test :as test :refer-macros [run-tests] :refer [report]]
    [chimera.core-test]
+   [chimera.date-test]
    [chimera.js-interop-test]
    [chimera.seq-test]
    [chimera.string-test]))
@@ -19,6 +20,7 @@
        (run-tests
         (test/empty-env ::test/default)
         'chimera.core-test
+        'chimera.date-test
         'chimera.js-interop-test
         'chimera.seq-test
         'chimera.string-test))


### PR DESCRIPTION
The change to moment.js date formatting broke a number of functions in our stack, moving all our date functions into one chimera and working on them from there makes it easier to track down and fix such errors and breaking lib changes.