### PR TITLE
Refactor call-ga

### DIFF
--- a/src/chimera/metrics.cljc
+++ b/src/chimera/metrics.cljc
@@ -13,7 +13,7 @@
   [& args]
   (let [final-args (remove-nil args)]
     #?(:clj (format "ga('%s');" (join "', '" final-args))
-       :cljs (when-let [g (aget js/window "ga")]
+       :cljs (when-let [g (.-ga js/window)]
               (try
                (apply g final-args)
                (catch js/TypeError e


### PR DESCRIPTION
The current implementation that uses `(aget js/window "ga")` seems to cause the following error for some reason when compiled in advanced mode (with source maps disabled.):

```
app.js:1168 Uncaught TypeError: a.ya is not a function
    at xc (app.js:1168)
    at i1 (app.js:3415)
    at rYb (app.js:4920)
    at sYb (app.js:4920)
    at app.js:5641
    at app.js:3380
    at Object.u [as executeDispatch] (app.js:24)
    at executeDispatch (app.js:28)
    at a (app.js:24)
    at Object.s [as executeDispatchesInOrder] (app.js:24)
```

This article mentions that using `aget` is not intended for javascript interop property access and property assignment: https://lwhorton.github.io/2018/10/20/clojurescript-interop-with-javascript.html