### PR TITLE
Replace apply with call

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
       [path]
       (str "resources/public/js/compiled/" path))
 
-(defproject onaio/chimera "0.0.12-SNAPSHOT"
+(defproject onaio/chimera "0.0.12"
   :description "Collection of useful Clojure(Script) functions."
   :dependencies [[clj-time "0.12.2"]
                  [com.cognitect/transit-cljs "0.8.239"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
       [path]
       (str "resources/public/js/compiled/" path))
 
-(defproject onaio/chimera "0.0.11"
+(defproject onaio/chimera "0.0.12-SNAPSHOT"
   :description "Collection of useful Clojure(Script) functions."
   :dependencies [[clj-time "0.12.2"]
                  [com.cognitect/transit-cljs "0.8.239"]

--- a/src/chimera/metrics.cljc
+++ b/src/chimera/metrics.cljc
@@ -14,10 +14,7 @@
   (let [final-args (remove-nil args)]
     #?(:clj (format "ga('%s');" (join "', '" final-args))
        :cljs (when-let [g (.-ga js/window)]
-              (try
-               (apply g final-args)
-               (catch js/TypeError e
-                (apply g nil final-args)))))))
+               (.call g nil final-args)))))
 
 (defprotocol AnalyticsEvent
   "Generic protocol for analytics events."


### PR DESCRIPTION
## What this PR fixes
### This PR fixes the error detailed here https://github.com/onaio/chimera/pull/33
  - As it turns out `.-` can be used interchangeably with `aget` and after testing this out, have found out that was not the cause of the error.
### This PR also ensures that google analytics events are being fired correctly
 - On other instances that use the master branch of chimera, google tag manager shows the following:
![Screenshot from 2020-05-08 09-14-33](https://user-images.githubusercontent.com/25260439/81377142-8af2ed00-910d-11ea-9277-3b1964465f3f.png)
![Screenshot from 2020-05-08 09-14-44](https://user-images.githubusercontent.com/25260439/81377230-b7a70480-910d-11ea-876f-7528cfea1848.png)


 - Using a version of chimera published from this branch:
![Screenshot from 2020-05-08 09-15-01(1)](https://user-images.githubusercontent.com/25260439/81377723-c04c0a80-910e-11ea-877c-1baea7bf1db3.png)
![Screenshot from 2020-05-08 09-15-06](https://user-images.githubusercontent.com/25260439/81377418-1bc9c880-910e-11ea-88d4-c61245051783.png)


## changes proposed in this PR
- Replace `(apply g final-args)` with `(.call g nil final-args)` and remove `try-catch` block