### PR TITLE
Add Options to Select One Types

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
       [path]
       (str "resources/public/js/compiled/" path))
 
-(defproject onaio/chimera "0.0.12"
+(defproject onaio/chimera "0.0.13"
   :description "Collection of useful Clojure(Script) functions."
   :dependencies [[clj-time "0.12.2"]
                  [com.cognitect/transit-cljs "0.8.239"]

--- a/src/chimera/csv_to_xlsform.clj
+++ b/src/chimera/csv_to_xlsform.clj
@@ -51,7 +51,7 @@
      :num-columns num-columns
      :header header
      :rows rows}))
- 
+
 (defn merge-types-into-vector-schema
   "Merge a list of types into the :types value in an vectorized schema.
    Returns an array-map."
@@ -65,8 +65,8 @@
                                      (assoc opts :type (nth types idx))
                                       (= "select_one" (nth types idx))
                                       (assoc :options (->> (nth columns idx)
-                                                          distinct
-                                                          (apply vector))))])
+                                                           distinct
+                                                           (apply vector))))])
                                  schema)))))
 
 (defn format-xlsform-names

--- a/src/chimera/csv_to_xlsform.clj
+++ b/src/chimera/csv_to_xlsform.clj
@@ -60,13 +60,14 @@
                 (not ((some-fn seq? vector?) types-raw)) vector)]
     (apply array-map
            (flatten (map-indexed (fn [idx [label opts]]
-                                   [label
-                                    (cond->
-                                     (assoc opts :type (nth types idx))
-                                      (= "select_one" (nth types idx))
-                                      (assoc :options (->> (nth columns idx)
-                                                           distinct
-                                                           (apply vector))))])
+                                   (let [indexed-type (nth types idx)]
+                                     [label
+                                      (cond->
+                                       (assoc opts :type indexed-type)
+                                        (= "select_one" indexed-type)
+                                        (assoc :options (->> (nth columns idx)
+                                                             distinct
+                                                             vec)))]))
                                  schema)))))
 
 (defn format-xlsform-names

--- a/src/chimera/csv_to_xlsform.clj
+++ b/src/chimera/csv_to_xlsform.clj
@@ -34,7 +34,10 @@
     (apply array-map
            (flatten (map-indexed (fn [idx [label opts]]
                                    [label
-                                    (assoc opts :type (nth types idx))])
+                                    (cond->
+                                     (assoc opts :type (nth types idx))
+                                      (= "select_one" (nth types idx))
+                                      (assoc :options "texas"))])
                                  schema)))))
 
 (defn format-xlsform-names

--- a/src/chimera/csv_to_xlsform.clj
+++ b/src/chimera/csv_to_xlsform.clj
@@ -25,10 +25,37 @@
       (join "\n" (cons header-row (rest (string/split csv-str #"\r\n|\r|\n"))))
       (str header-row "\n" csv-str))))
 
+(defn- build-default-header
+  "Create a default header matching the number of columns in an assumed data
+   only CSV"
+  [rows]
+  ;; needs translation?
+  (map #(str "column %") (range 1 (-> rows count inc))))
+
+(defn parse-csv-data [csv has-header?]
+  (let [parsed-csv (parse-csv csv)
+        parsed-csv (if (includes? (join (flatten parsed-csv)) "\r")
+                     (parse-csv csv :end-of-line "\r")
+                     parsed-csv)
+        ;; removes blank rows
+        csv-vector (remove (fn [r] (and (= (count r) 1)
+                                        (string/blank? (first r))))
+                           parsed-csv)
+        [header & rows] (when has-header?
+                          (cond->> csv-vector
+                            (not has-header?)
+                            (cons (build-default-header csv-vector))))
+        num-columns (count header)
+        columns (if rows (transpose rows) (repeat num-columns []))]
+    {:columns columns
+     :num-columns num-columns
+     :header header
+     :rows rows}))
+ 
 (defn merge-types-into-vector-schema
   "Merge a list of types into the :types value in an vectorized schema.
    Returns an array-map."
-  [schema types-raw]
+  [schema types-raw columns]
   (let [types (cond-> types-raw
                 (not ((some-fn seq? vector?) types-raw)) vector)]
     (apply array-map
@@ -37,7 +64,9 @@
                                     (cond->
                                      (assoc opts :type (nth types idx))
                                       (= "select_one" (nth types idx))
-                                      (assoc :options "texas"))])
+                                      (assoc :options (->> (nth columns idx)
+                                                          distinct
+                                                          (apply vector))))])
                                  schema)))))
 
 (defn format-xlsform-names
@@ -51,13 +80,6 @@
   [f v e]
   `(try (not-every? #(or (false? %) (nil? %)) (doall (map ~f ~v)))
         (catch ~e _# false)))
-
-(defn- build-default-header
-  "Create a default header matching the number of columns in an assumed data
-   only CSV"
-  [rows]
-  ;; needs translation?
-  (map (str "column %") (range 1 (-> rows count inc))))
 
 (defn- is-geopoint-str?
   "Return true if this string looks like a geopoint string, otherwise return
@@ -168,20 +190,8 @@
        exception. If needed we could add :rename or :first options."
   [csv & {:keys [has-header? duplicate-mode] :or {has-header? true
                                                   duplicate-mode :fail}}]
-  (let [parsed-csv (parse-csv csv)
-        parsed-csv (if (includes? (join (flatten parsed-csv)) "\r")
-                     (parse-csv csv :end-of-line "\r")
-                     parsed-csv)
-        ;; removes blank rows
-        csv-vector (remove (fn [r] (and (= (count r) 1)
-                                        (string/blank? (first r))))
-                           parsed-csv)
-        [header & rows] (if has-header?
-                          (cond->> csv-vector
-                            (not has-header?)
-                            (cons (build-default-header csv-vector))))
-        num-columns (count header)
-        columns (if rows (transpose rows) (repeat num-columns []))]
+  (let [{:keys [num-columns header columns rows]}
+        (parse-csv-data csv has-header?)]
     (when (not= (distinct header) header)
       ;; There are duplicate columns
       (case duplicate-mode

--- a/test/chimera/csv_to_xlsform_test.clj
+++ b/test/chimera/csv_to_xlsform_test.clj
@@ -72,7 +72,7 @@
 
 (facts "about merge-types-into-vector-schema"
        (fact "should handle types arg as a string"
-             (merge-types-into-vector-schema {:a {:type :old}} "new")
+             (merge-types-into-vector-schema {:a {:type :old}} "new" [["new"]])
              => {:a {:type "new"}}))
 
 (facts "about rename-header-columns"

--- a/test/chimera/csv_to_xlsform_test.clj
+++ b/test/chimera/csv_to_xlsform_test.clj
@@ -72,8 +72,15 @@
 
 (facts "about merge-types-into-vector-schema"
        (fact "should handle types arg as a string"
-             (merge-types-into-vector-schema {:a {:type :old}} "new" [["new"]])
-             => {:a {:type "new"}}))
+             (merge-types-into-vector-schema {:a {:type :old}}
+                                             ["new"] [["texas" "washington"]])
+             => {:a {:type "new"}})
+
+       (fact "should add otions if options if type is select one"
+             (merge-types-into-vector-schema {:a {:type "text"}}
+                                             ["select_one"]
+                                             [["texas" "washington"]])
+             => {:a {:type "select_one" :options ["texas" "washington"]}}))
 
 (facts "about rename-header-columns"
        (fact "should replace header row if first-row-as-labels? true"


### PR DESCRIPTION
Fixes #36 
Add an options key when type is select one
Get the values of `options`  from columns by getting the index and removing duplicates