### PR TITLE
Ensure gtag is called correctly when event is dispatched

### DIFF
--- a/src/chimera/metrics.cljs
+++ b/src/chimera/metrics.cljs
@@ -5,7 +5,7 @@
    If `gtag` does not exist do nothing."
   [event name args]
   (if-let [gtag (.-gtag js/window)]
-    (.call gtag event name (clj->js args))
+    (gtag event name (clj->js args))
     (js/console.warn "gtag object is not defined")))
 
 (defn call-analytics-event

--- a/test/chimera/metrics_test.cljs
+++ b/test/chimera/metrics_test.cljs
@@ -1,0 +1,14 @@
+(ns chimera.metrics-test
+  (:require-macros [cljs.test :refer (is deftest)])
+  (:require [cljs.test :as t]
+            [chimera.metrics :as metrics]))
+
+(deftest test-call-gtag
+  (let [event "click_event"
+        name "dataview-toggle"
+        args {:value "on"}]
+    (set! (.-gtag js/window) (fn [event name args]
+                               (is (= event "click_event"))
+                               (is (= name "dataview-toggle"))
+                               (is (= (js->clj args) {"value" "on"}))))
+    (metrics/call-gtag event name args)))

--- a/test/test_runner.cljs
+++ b/test/test_runner.cljs
@@ -4,6 +4,7 @@
    [chimera.core-test]
    [chimera.date-test]
    [chimera.js-interop-test]
+   [chimera.metrics-test]
    [chimera.seq-test]
    [chimera.string-test]))
 
@@ -11,6 +12,7 @@
 
 (doo-tests 'chimera.core-test
            'chimera.date-test
+           'chimera.metrics-test
            'chimera.js-interop-test
            'chimera.seq-test
            'chimera.string-test)


### PR DESCRIPTION
I have observed that with `(.call gtag event name (clj->js args))`; no data is sent to google analytics when this function is called
This is fixed by refactoring to: `(gtag event name (clj->js args))`